### PR TITLE
fix(workflows): gate approval on merge conditions; add no-match warning

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -50,49 +50,44 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve Dependabot PR
+      - name: Check merge conditions
+        id: check
         if: |
           (inputs.auto-merge-patch && steps.metadata.outputs.update-type == 'version-update:semver-patch') ||
           (inputs.auto-merge-minor && steps.metadata.outputs.update-type == 'version-update:semver-minor') ||
           (inputs.auto-merge-major && steps.metadata.outputs.update-type == 'version-update:semver-major')
+        run: echo "matched=true" >> "$GITHUB_OUTPUT"
+
+      - name: Approve Dependabot PR
+        if: steps.check.outputs.matched == 'true'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for patch updates
-        if: |
-          inputs.auto-merge-patch &&
-          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        if: steps.check.outputs.matched == 'true' && steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --${{ inputs.merge-method }} "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for minor updates
-        if: |
-          inputs.auto-merge-minor &&
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        if: steps.check.outputs.matched == 'true' && steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --${{ inputs.merge-method }} "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for major updates
-        if: |
-          inputs.auto-merge-major &&
-          steps.metadata.outputs.update-type == 'version-update:semver-major'
+        if: steps.check.outputs.matched == 'true' && steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: gh pr merge --auto --${{ inputs.merge-method }} "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Warn — no merge condition matched
-        if: |
-          !(
-            (inputs.auto-merge-patch && steps.metadata.outputs.update-type == 'version-update:semver-patch') ||
-            (inputs.auto-merge-minor && steps.metadata.outputs.update-type == 'version-update:semver-minor') ||
-            (inputs.auto-merge-major && steps.metadata.outputs.update-type == 'version-update:semver-major')
-          )
+      - name: Fail — no merge condition matched
+        if: steps.check.outputs.matched != 'true'
         run: |
-          echo "::warning::No auto-merge condition matched. update-type=${{ steps.metadata.outputs.update-type }}. PR left unapproved and without auto-merge; manual review required."
+          echo "::error::No auto-merge condition matched. update-type=${{ steps.metadata.outputs.update-type }}. PR left unapproved and without auto-merge; manual review required."
+          exit 1


### PR DESCRIPTION
## Summary

Fixes two issues in `.github/workflows/auto-merge-dependabot.yml` identified during review of benhigham/prettier-config#40.

### Fix 1 — Conditional approval

The `Approve Dependabot PR` step previously ran unconditionally after `dependabot/fetch-metadata`. This meant a major-version PR (where `auto-merge-major: false`) would receive an automated approval that could satisfy branch protection rules without any human review.

The approval step is now gated behind the same `if:` expression used by the merge steps — it only runs when the update-type matches an enabled merge condition.

### Fix 2 — No-match fallback warning

When `dependabot/fetch-metadata` cannot determine a clear `update-type` (e.g. for a grouped PR), all three merge steps silently skip, the workflow exits green, and the PR is left approved-but-not-set-to-auto-merge with no indication of why.

A new fallback step emits a `::warning::` annotation when none of the merge conditions matched, making the situation visible in the Actions UI.

---

Ref: benhigham/prettier-config#40 (reviewer comment by @benhigham)