### PR TITLE
fix(workflows): remove unused `issues: write` and fix permission comments

### DIFF
--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -56,11 +56,10 @@ jobs:
   release:
     name: Create release
     permissions:
-      attestations: write # to create attestations (changesets/action)
-      contents: write # to create the release (changesets/action)
-      id-token: write # for npm provenance verification (changesets/action)
-      issues: write # to post issue comments (changesets/action)
-      pull-requests: write # to create the pull request (changesets/action)
+      attestations: write # to persist npm provenance attestations (npm publish)
+      contents: write # to push branches/tags and create GitHub Releases (changesets/action)
+      id-token: write # to mint OIDC token for npm provenance generation (npm publish)
+      pull-requests: write # to create and update the version PR (changesets/action)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

- **Remove `issues: write`** from `release-changesets.yml` — audited `changesets/action` source and found zero `octokit.rest.issues.*` calls, so this permission is unnecessary
- **Fix 4 permission comments** to accurately describe what each permission is for and attribute it to the correct consumer (`changesets/action` vs `npm publish`)

Mirrors the fixes applied to `commitlint-config` in [PR #49](https://github.com/benhigham/commitlint-config/pull/49).

## Test plan

- [ ] Verify workflow YAML is valid (no syntax errors)
- [ ] Confirm a release triggered by merging changesets still works end-to-end (creates version PR, publishes to npm with provenance)