### PR TITLE
fix(workflows): add auto-merge pre-flight check and document concurrency scope

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -81,7 +81,10 @@ jobs:
       - name: Verify auto-merge is enabled
         if: steps.check.outputs.matched == 'true'
         run: |
-          AUTO_MERGE=$(gh api "repos/${{ github.repository }}" --jq '.allow_auto_merge')
+          if ! AUTO_MERGE=$(gh api "repos/${{ github.repository }}" --jq '.allow_auto_merge' 2>&1); then
+            echo "::error::Failed to query repository settings via GitHub API. Response: ${AUTO_MERGE}"
+            exit 1
+          fi
           if [ "$AUTO_MERGE" != "true" ]; then
             echo "::error::Auto-merge is not enabled for this repository. Enable it in Settings > General > Pull Requests > Allow auto-merge."
             exit 1


### PR DESCRIPTION
## Summary

- Add a "Verify auto-merge is enabled" guard step that checks the repository's `allow_auto_merge` setting before approving a PR, replacing a cryptic GitHub API error with a human-readable message pointing to the exact setting
- Document that the concurrency group's `${{ github.workflow }}` resolves to the caller's workflow name, so each caller gets its own concurrency scope

Implements the remaining suggestions from a [review of the auto-merge workflow](../blob/main/.github/workflows/auto-merge-dependabot.yml).

## Test plan

- [ ] Verify workflow syntax is valid (`actionlint` or GitHub's workflow editor)
- [ ] Test on a repo with auto-merge **disabled** — confirm the new step fails with the expected error message
- [ ] Test on a repo with auto-merge **enabled** — confirm the workflow proceeds normally through approval and merge