### PR TITLE
fix(release): add registry-url for OIDC npm auth

### DIFF
--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -72,6 +72,7 @@ jobs:
           node-version-file: package.json
           cache: pnpm
           cache-dependency-path: '**/pnpm-lock.yaml'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
The publish step is failing with `npm error need auth` because `actions/setup-node` needs `registry-url` to configure `.npmrc` for OIDC token exchange. This was accidentally removed during the #14 review.

Adds `registry-url: 'https://registry.npmjs.org'` back to the setup-node step.

_Raised by Kael 🔗_